### PR TITLE
Switch to multi-docker stage build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+export COMPOSE_DOCKER_CLI_BUILD=1
+
+.EXPORT_ALL_VARIABLES: ;
+
 .PHONY: build
 build:
-	docker-compose build --parallel
+	docker-compose build
 
 .PHONY: replace-hosts
 replace-hosts:

--- a/bank/Dockerfile
+++ b/bank/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15
+# syntax=docker/dockerfile:1.1.3-experimental
+FROM golang:1.15 as builder
 
 WORKDIR /app
 
@@ -7,8 +8,15 @@ COPY go.sum .
 RUN go mod download
 
 COPY bank .
-RUN go build -o main .
+RUN --mount=type=cache,target=/root/.cache/go-build,mode=777 \
+    CGO_ENABLED=0 go build -tags static_all -o main .
 
-EXPOSE 8080
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /app/data data
+COPY --from=builder /app/main .
 
 CMD ["./main"]

--- a/consent-admin/Dockerfile
+++ b/consent-admin/Dockerfile
@@ -1,23 +1,18 @@
-FROM golang:1.15.2
-
-USER root
-
-RUN apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt -y install nodejs
+# syntax=docker/dockerfile:1.1.3-experimental
+FROM node:14.15.1 as js-builder
 
 WORKDIR /app/web/app
 
 COPY consent-admin/web/app/package.json package.json
 COPY consent-admin/web/app/package-lock.json package-lock.json
-
 RUN npm install --no-audit --prefer-offline
 
 COPY consent-admin/web/app/tsconfig.json tsconfig.json
 COPY consent-admin/web/app/public public
 COPY consent-admin/web/app/src src
-
 RUN npm run build
+
+FROM golang:1.15.2 as go-builder
 
 WORKDIR /app
 
@@ -26,8 +21,15 @@ COPY go.sum .
 RUN go mod download
 
 COPY consent-admin .
-RUN go build -o main .
+RUN --mount=type=cache,target=/root/.cache/go-build,mode=777 \
+    CGO_ENABLED=0 go build -tags static_all -o main .
 
-EXPOSE 8080
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=go-builder /app/main .
+COPY --from=js-builder /app/web/app/build ./web/app/build
 
 CMD ["./main"]

--- a/consent-page/Dockerfile
+++ b/consent-page/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15
+# syntax=docker/dockerfile:1.1.3-experimental
+FROM golang:1.15 as builder
 
 WORKDIR /app
 
@@ -7,8 +8,16 @@ COPY go.sum .
 RUN go mod download
 
 COPY consent-page .
-RUN go build -o main .
+RUN --mount=type=cache,target=/root/.cache/go-build,mode=777 \
+    CGO_ENABLED=0 go build -tags static_all -o main .
 
-EXPOSE 8080
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /app/templates templates
+COPY --from=builder /app/assets assets
+COPY --from=builder /app/main .
 
 CMD ["./main"]

--- a/consent-self-service/Dockerfile
+++ b/consent-self-service/Dockerfile
@@ -1,10 +1,5 @@
-FROM golang:1.15.2
-
-USER root
-
-RUN apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt -y install nodejs
+# syntax=docker/dockerfile:1.1.3-experimental
+FROM node:14.15.1 as js-builder
 
 WORKDIR /app/web/app
 
@@ -19,6 +14,8 @@ COPY consent-self-service/web/app/src src
 
 RUN npm run build
 
+FROM golang:1.15.2 as go-builder
+
 WORKDIR /app
 
 COPY go.mod .
@@ -26,8 +23,15 @@ COPY go.sum .
 RUN go mod download
 
 COPY consent-self-service .
-RUN go build -o main .
+RUN --mount=type=cache,target=/root/.cache/go-build,mode=777 \
+    CGO_ENABLED=0 go build -tags static_all -o main .
 
-EXPOSE 8080
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=go-builder /app/main .
+COPY --from=js-builder /app/web/app/build ./web/app/build
 
 CMD ["./main"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: tpp/Dockerfile
     container_name: tpp
+    restart: always
     ports:
       - "8090:8090"
     volumes:
@@ -29,6 +30,7 @@ services:
       context: .
       dockerfile: financroo/Dockerfile
     container_name: financroo
+    restart: always
     ports:
       - "8091:8091"
     volumes:
@@ -54,6 +56,7 @@ services:
       context: .
       dockerfile: consent-page/Dockerfile
     container_name: consent-page
+    restart: always
     ports:
       - "8080:8080"
     volumes:
@@ -74,6 +77,7 @@ services:
       context: .
       dockerfile: consent-self-service/Dockerfile
     container_name: consent-self-service
+    restart: always
     ports:
       - "8085:8085"
     volumes:
@@ -101,6 +105,7 @@ services:
       context: .
       dockerfile: consent-admin/Dockerfile
     container_name: consent-admin
+    restart: always
     ports:
       - "8086:8086"
     volumes:
@@ -129,6 +134,7 @@ services:
       context: .
       dockerfile: bank/Dockerfile
     container_name: bank
+    restart: always
     ports:
       - "8070:8070"
     volumes:
@@ -144,6 +150,7 @@ services:
 
   acp:
     container_name: acp
+    restart: always
     image: ${ACP_DOCKER_IMAGE}:${ACP_VERSION}
     ports:
      - 8443:8443
@@ -172,7 +179,7 @@ services:
   crdb:
     container_name: crdb
     image: cockroachdb/cockroach:v20.1.7
-    #restart: on-failure
+    restart: on-failure
     ports:
      - 26257:26257
      - 8081:8080
@@ -181,5 +188,6 @@ services:
   hazelcast:
     container_name: hazelcast
     image: hazelcast/hazelcast:3.12
+    restart: on-failure
     ports:
       - 5701:5701

--- a/financroo/Dockerfile
+++ b/financroo/Dockerfile
@@ -1,10 +1,5 @@
-FROM golang:1.15.2
-
-USER root
-
-RUN apt-get update
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt -y install nodejs
+# syntax=docker/dockerfile:1.1.3-experimental
+FROM node:14.15.1 as js-builder
 
 WORKDIR /app/web/app
 
@@ -19,6 +14,8 @@ COPY financroo/web/app/src src
 
 RUN npm run build
 
+FROM golang:1.15.2 as go-builder
+
 WORKDIR /app
 
 COPY go.mod .
@@ -28,8 +25,15 @@ RUN go mod download
 COPY client client
 COPY models models
 COPY financroo .
-RUN go build -o main .
+RUN --mount=type=cache,target=/root/.cache/go-build,mode=777 \
+    CGO_ENABLED=0 go build -tags static_all -o main .
 
-EXPOSE 8091
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=go-builder /app/main .
+COPY --from=js-builder /app/web/app/build ./web/app/build
 
 CMD ["./main"]

--- a/tpp/Dockerfile
+++ b/tpp/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15
+# syntax=docker/dockerfile:1.1.3-experimental
+FROM golang:1.15 as builder
 
 WORKDIR /app
 
@@ -9,8 +10,16 @@ RUN go mod download
 COPY client client
 COPY models models
 COPY tpp .
-RUN go build -o main .
+RUN --mount=type=cache,target=/root/.cache/go-build,mode=777 \
+    CGO_ENABLED=0 go build -tags static_all -o main .
 
-EXPOSE 8080
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /app/templates templates
+COPY --from=builder /app/assets assets
+COPY --from=builder /app/main .
 
 CMD ["./main"]


### PR DESCRIPTION
```
➜  openbanking-sandbox feature/multi-stage-docker ✗ docker images | grep openbanking
openbanking-sandbox_bank                                        latest              0b861a4e8c7d        About a minute ago   29.8MB
openbanking-sandbox_consent-page                                latest              44770aa37eee        About a minute ago   31.9MB
openbanking-sandbox_tpp                                         latest              1296b7817acc        3 minutes ago        36.2MB
openbanking-sandbox_consent-self-service                        latest              ad4190b752f8        9 minutes ago        32MB
openbanking-sandbox_financroo                                   latest              24e443673636        21 minutes ago       34.2MB
openbanking-sandbox_consent-admin                               latest              468535ec99e8        30 minutes ago       32MB
```

How to quickly rebuild one service?

```
docker-compose build financroo
docker-compose up -d financoo
```

Golang build cache is cached so it's very fast to rebuild go binary.

Small changes to frontend app requires full and slow rebuild of entire app.