### PR TITLE
Use fixed compose project name

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+COMPOSE_PROJECT_NAME=openbanking-sandbox
+
 # url where acp is deployed
 ACP_URL=https://localhost:8443
 


### PR DESCRIPTION
By default, if the project name is not specified for docker-compose, the name of the directory is used.
This PR fixes an issue when someone runs acp and then renames the directory and then tries to run for example: `make clean`.